### PR TITLE
Add decryption status reporting

### DIFF
--- a/app.py
+++ b/app.py
@@ -228,6 +228,13 @@ def index():
                     f['downloaded_at'] = datetime.fromisoformat(f['downloaded_at']).strftime('%Y-%m-%d %H-%M-%S')
                 except Exception:
                     pass
+            status = f.get('decryption_success')
+            if status is True:
+                f['decryption_status'] = 'Success'
+            elif status is False:
+                f['decryption_status'] = 'Failed'
+            else:
+                f['decryption_status'] = 'Pending'
 
         # Get files shared with the current user
         shared_files = files_table.search(
@@ -319,7 +326,8 @@ def upload_file():
             'path': file_path,
             'created_at': datetime.now().isoformat(),
             'downloaded_at': None,
-            'uploaded_by': session['username']
+            'uploaded_by': session['username'],
+            'decryption_success': None
         })
         share_link = url_for('view_file', file_id=unique_id, _external=True)
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
@@ -445,6 +453,23 @@ def confirm_view_file(file_id):
         flash('File not found')
         return redirect(url_for('index'))
     return render_template('view.html', file_id=file_id, original_name=file_info['original_name'])
+
+
+@app.route('/report_decryption/<file_id>', methods=['POST'])
+def report_decryption(file_id):
+    """Record whether the downloaded file was decrypted successfully."""
+    files_table = get_files_table()
+    file_info = files_table.get(File.id == file_id)
+    if not file_info:
+        return {'error': 'File not found'}, 404
+
+    data = request.get_json(silent=True) or {}
+    if 'success' not in data:
+        return {'error': 'Invalid request'}, 400
+
+    if file_info.get('decryption_success') is None:
+        files_table.update({'decryption_success': bool(data['success'])}, File.id == file_id)
+    return {'status': 'recorded'}
 
 
 print("upload folder: " + app.config['UPLOAD_FOLDER'])

--- a/templates/index.html
+++ b/templates/index.html
@@ -56,6 +56,7 @@
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">File Name</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Uploaded At</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Downloaded</th>
+                    <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Decryption</th>
                     <th class="px-4 py-2 text-left text-xs font-medium text-gray-500 uppercase">Actions</th>
                 </tr>
             </thead>
@@ -70,6 +71,9 @@
                         {% else %}
                             <span class="text-gray-500">No</span>
                         {% endif %}
+                    </td>
+                    <td class="px-4 py-2">
+                        {{ file.decryption_status }}
                     </td>
                     <td class="px-4 py-2 whitespace-nowrap">
                         <form method="post" action="{{ url_for('delete_file', file_id=file.id) }}" class="inline-block">

--- a/templates/view.html
+++ b/templates/view.html
@@ -53,10 +53,20 @@
             a.remove();
             URL.revokeObjectURL(a.href);
             document.getElementById('status').textContent = 'Download complete.';
+            fetch("{{ url_for('report_decryption', file_id=file_id) }}", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ success: true })
+            }).catch(() => {});
             decBytes.fill(0);
             fileBytes.fill(0);
         } catch (err) {
             document.getElementById('status').textContent = 'Incorrect password or corrupted file. The file was deleted from the server to avoid attempted password breaking. Ask author to upload the file again.';
+            fetch("{{ url_for('report_decryption', file_id=file_id) }}", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ success: false })
+            }).catch(() => {});
         } finally {
             encData.fill(0);
             salt.fill(0);

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -193,3 +193,23 @@ def test_delete_file_after_download(client, app, files_table):
     assert response.status_code == 200
     assert b'File deleted successfully' in response.data
     assert files_table.get(File.id == file_id) is None
+
+
+def test_report_decryption_success(client, app, files_table):
+    login_user(client, 'testuser', 'password')
+
+    file_id = upload_file_for_user(client, app, files_table, 'dec.txt', 'content', 'testuser')
+
+    client.get(url_for('download_file', file_id=file_id))
+
+    res = client.post(url_for('report_decryption', file_id=file_id), json={'success': True})
+    assert res.status_code == 200
+
+    File = Query()
+    info = files_table.get(File.id == file_id)
+    assert info['decryption_success'] is True
+
+
+def test_report_decryption_file_not_found(client):
+    res = client.post(url_for('report_decryption', file_id='missing'), json={'success': False})
+    assert res.status_code == 404


### PR DESCRIPTION
## Summary
- track `decryption_success` for uploaded files
- report decryption result from browser
- expose `/report_decryption/<id>` route
- display decryption status on dashboard
- test decryption reporting

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685130cbca208322990f1173041b7409