### PR TITLE
Add expiry date handling for shared files

### DIFF
--- a/app.py
+++ b/app.py
@@ -202,6 +202,41 @@ def allowed_file(filename):
     return '.' in filename and filename.rsplit('.', 1)[1].lower() in allowed
 
 
+def check_and_handle_expiry(file_info):
+    """Check if the given file has expired and handle cleanup."""
+    if not file_info:
+        return False
+
+    expiry_at = file_info.get('expiry_at')
+    status = file_info.get('status')
+    if not expiry_at or status == 'expired':
+        return status == 'expired'
+
+    try:
+        expiry_dt = datetime.fromisoformat(expiry_at)
+    except ValueError:
+        return False
+
+    if datetime.now() >= expiry_dt:
+        # Remove file from storage
+        if STORAGE_BACKEND == 's3':
+            try:
+                s3_client.delete_object(Bucket=S3_BUCKET, Key=file_info['path'])
+            except Exception:
+                pass
+        else:
+            try:
+                os.remove(file_info['path'])
+            except FileNotFoundError:
+                pass
+        files_table = get_files_table()
+        files_table.update({'status': 'expired'}, File.id == file_info['id'])
+        file_info['status'] = 'expired'
+        return True
+
+    return False
+
+
 @app.errorhandler(RequestEntityTooLarge)
 def handle_large_file(error):
     """Return a user-friendly message when the uploaded file exceeds the limit."""
@@ -313,13 +348,23 @@ def upload_file():
             os.makedirs(upload_dir, exist_ok=True)
             file_path = os.path.join(upload_dir, unique_id)
             file.save(file_path)
+        expiry_raw = request.form.get('expiry')
+        expiry_iso = None
+        if expiry_raw:
+            try:
+                expiry_iso = datetime.fromisoformat(expiry_raw).isoformat()
+            except ValueError:
+                expiry_iso = None
+
         files_table.insert({
             'id': unique_id,
             'original_name': filename,
             'path': file_path,
             'created_at': datetime.now().isoformat(),
             'downloaded_at': None,
-            'uploaded_by': session['username']
+            'uploaded_by': session['username'],
+            'expiry_at': expiry_iso,
+            'status': 'active'
         })
         share_link = url_for('view_file', file_id=unique_id, _external=True)
         if request.headers.get('X-Requested-With') == 'XMLHttpRequest':
@@ -344,6 +389,9 @@ def download_file(file_id):
         return redirect(url_for('index'))
     if 'downloaded_at' in file_info and file_info['downloaded_at'] is not None:
         flash('This file has already been downloaded at {}'.format(file_info['downloaded_at']))
+        return redirect(url_for('index'))
+    if check_and_handle_expiry(file_info):
+        flash('File has expired')
         return redirect(url_for('index'))
     # Mark file as downloaded (set timestamp)
     files_table.update({'downloaded_at': datetime.now().isoformat()}, File.id == file_id)
@@ -435,6 +483,9 @@ def view_file(file_id):
     if not file_info or file_info['downloaded_at'] is not None:
         flash('File not found')
         return redirect(url_for('index'))
+    if check_and_handle_expiry(file_info):
+        flash('File has expired')
+        return redirect(url_for('index'))
     return render_template('confirm_download.html', file_id=file_id, original_name=file_info['original_name'])
 
 @app.route('/view/<file_id>/confirm', methods=['POST'])
@@ -443,6 +494,9 @@ def confirm_view_file(file_id):
     file_info = files_table.get(File.id == file_id)
     if not file_info or file_info['downloaded_at'] is not None:
         flash('File not found')
+        return redirect(url_for('index'))
+    if check_and_handle_expiry(file_info):
+        flash('File has expired')
         return redirect(url_for('index'))
     return render_template('view.html', file_id=file_id, original_name=file_info['original_name'])
 

--- a/templates/index.html
+++ b/templates/index.html
@@ -32,6 +32,11 @@
                     <input id="password" type="password" class="mt-1 p-2 border rounded-md w-full" required>
                 </div>
 
+                <div>
+                    <label for="expiry" class="block text-sm font-medium text-gray-700">Expiry Date (optional)</label>
+                    <input id="expiry" name="expiry" type="datetime-local" class="mt-1 p-2 border rounded-md w-full">
+                </div>
+
                 <div class="flex justify-center">
                     <button type="submit" class="bg-indigo-600 text-white px-6 py-2 rounded-md hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2">
                         Upload File
@@ -133,6 +138,10 @@ if (document.querySelector('form')) {
         const encBlob = new Blob([total], { type: 'application/octet-stream' });
         const formData = new FormData();
         formData.append('file', new File([encBlob], file.name));
+        const expiryInput = document.getElementById('expiry');
+        if (expiryInput && expiryInput.value) {
+            formData.append('expiry', expiryInput.value);
+        }
 
         const res = await fetch("{{ url_for('upload_file') }}", {
             method: 'POST',

--- a/tests/integration/test_files.py
+++ b/tests/integration/test_files.py
@@ -3,6 +3,7 @@ import os
 from flask import url_for, session, current_app
 from tinydb import Query
 import io # For creating dummy file content for uploads
+from datetime import datetime, timedelta
 # Fixtures: 'app', 'client', 'db_instance', 'files_table' from conftest.py
 # Test users from conftest.py: 'testuser:password:false', 'adminuser:adminpass:true'
 
@@ -193,3 +194,24 @@ def test_delete_file_after_download(client, app, files_table):
     assert response.status_code == 200
     assert b'File deleted successfully' in response.data
     assert files_table.get(File.id == file_id) is None
+
+
+def test_view_file_expired(client, app, files_table):
+    login_user(client, 'testuser', 'password')
+
+    expiry = (datetime.now() - timedelta(minutes=1)).strftime('%Y-%m-%dT%H:%M')
+    file_data = {
+        'file': (io.BytesIO(b'expired'), 'exp.txt'),
+        'expiry': expiry
+    }
+    client.post(url_for('upload_file'), data=file_data, content_type='multipart/form-data')
+
+    File = Query()
+    file_info = files_table.get(File.original_name == 'exp.txt')
+    file_id = file_info['id']
+
+    response = client.get(url_for('view_file', file_id=file_id), follow_redirects=True)
+    assert b'File has expired' in response.data
+    updated = files_table.get(File.id == file_id)
+    assert updated['status'] == 'expired'
+    assert not os.path.exists(updated['path'])


### PR DESCRIPTION
## Summary
- allow specifying optional expiry date when uploading
- store expiry information in DB
- remove expired files when accessed and mark as expired
- add expiry field to upload form and JS handler
- test share expiry logic

## Testing
- `pip install -q -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_685133f2fe408322907c7fd556d3f902